### PR TITLE
Fix typo and add trailing newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,4 @@
 # Запуск
 1. Запустить локальный сервис Apache Kafka на порту `9092`;
 2. Запустить Consumer;
-3. Запустить Producer;
-4. Отправить GET запрос на адресс `localhost:8080/api/v1/wikimedia`.
+3. Запустить Producer;4. Отправить GET запрос на адрес `localhost:8080/api/v1/wikimedia`.


### PR DESCRIPTION
## Summary
- fix the spelling of `адрес` in README
- ensure README ends with a newline

## Testing
- `./mvnw -q test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e5e30b1348325b70d3341f771c6f8